### PR TITLE
fix: fixed expense update.

### DIFF
--- a/.sqlx/query-0fdc8b203d083405abc72c0be3e061d271a60013f3b4f62ece4146717494f36a.json
+++ b/.sqlx/query-0fdc8b203d083405abc72c0be3e061d271a60013f3b4f62ece4146717494f36a.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT id, description, price, expense_type as \"expense_type: ExpenseType\", is_essencial, date\n                FROM expenses ORDER BY date ASC",
+  "query": "SELECT id, description, price, expense_type as \"expense_type: ExpenseType\", is_essencial, date\n        FROM expenses\n        WHERE ((date >= $1) OR ($1 IS NULL))\n        AND ((date <= $2) OR ($2 IS NULL))\n        ORDER BY date ASC",
   "describe": {
     "columns": [
       {
@@ -49,7 +49,10 @@
       }
     ],
     "parameters": {
-      "Left": []
+      "Left": [
+        "Date",
+        "Date"
+      ]
     },
     "nullable": [
       false,
@@ -60,5 +63,5 @@
       false
     ]
   },
-  "hash": "c6a4023380d34cfa6892168ae56ef7c3951792638f4d6779394922fa18516e61"
+  "hash": "0fdc8b203d083405abc72c0be3e061d271a60013f3b4f62ece4146717494f36a"
 }

--- a/.sqlx/query-563b6d224d9bcaadd197cf3751c45cd4732fcf1589fc82cc456bb90a2afbe06e.json
+++ b/.sqlx/query-563b6d224d9bcaadd197cf3751c45cd4732fcf1589fc82cc456bb90a2afbe06e.json
@@ -1,0 +1,85 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        UPDATE expenses SET\n            description = COALESCE($1, description),\n            price = COALESCE($2, price),\n            expense_type = COALESCE($3 :: expense_type, expense_type),\n            is_essencial = COALESCE($4, is_essencial),\n            date = COALESCE($5, date)\n        WHERE id = $6\n        RETURNING id, description, price, expense_type as \"expense_type: ExpenseType\", is_essencial, date\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "description",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "price",
+        "type_info": "Float4"
+      },
+      {
+        "ordinal": 3,
+        "name": "expense_type: ExpenseType",
+        "type_info": {
+          "Custom": {
+            "name": "expense_type",
+            "kind": {
+              "Enum": [
+                "food",
+                "transport",
+                "health",
+                "education",
+                "entertainment",
+                "other"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "is_essencial",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 5,
+        "name": "date",
+        "type_info": "Date"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Float4",
+        {
+          "Custom": {
+            "name": "expense_type",
+            "kind": {
+              "Enum": [
+                "food",
+                "transport",
+                "health",
+                "education",
+                "entertainment",
+                "other"
+              ]
+            }
+          }
+        },
+        "Bool",
+        "Date",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "563b6d224d9bcaadd197cf3751c45cd4732fcf1589fc82cc456bb90a2afbe06e"
+}

--- a/.sqlx/query-c0b3ff4b18613d8e9bfbe272d944d092064401dce01b0fe509fd3e3976d5ec8f.json
+++ b/.sqlx/query-c0b3ff4b18613d8e9bfbe272d944d092064401dce01b0fe509fd3e3976d5ec8f.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT id, description, price, expense_type as \"expense_type: ExpenseType\", is_essencial, date\n                FROM expenses WHERE date BETWEEN $1 AND $2 ORDER BY date ASC",
+  "query": "SELECT id, description, price, expense_type as \"expense_type: ExpenseType\", is_essencial, date\n        FROM expenses WHERE id = $1",
   "describe": {
     "columns": [
       {
@@ -50,8 +50,7 @@
     ],
     "parameters": {
       "Left": [
-        "Date",
-        "Date"
+        "Int4"
       ]
     },
     "nullable": [
@@ -63,5 +62,5 @@
       false
     ]
   },
-  "hash": "59183ce536917b910db8f480b490771a7440e56fa6f09a36a02f3fa79516f95b"
+  "hash": "c0b3ff4b18613d8e9bfbe272d944d092064401dce01b0fe509fd3e3976d5ec8f"
 }

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -48,7 +48,7 @@ macro_rules! EDITABLE_TABLE_ROW {
                 <button class=\"btn btn-danger\" hx-get=\"/expenses/{}\">
                   Cancel
                 </button>
-                <button class=\"btn btn-danger\" hx-put=\"/expenses/{}\" hx-include=\"closest tr\">
+                <button class=\"btn btn-danger\" hx-put=\"/expenses/{}\" hx-ext=\"json-enc\" hx-include=\"closest tr\">
                   Save
                 </button>
             </td>

--- a/src/hypermedia_router.rs
+++ b/src/hypermedia_router.rs
@@ -1,7 +1,7 @@
 use crate::{
     constant::{EDITABLE_TABLE_ROW, TABLE_ROW},
-    schema::{Expense, ExpenseType, GetExpense},
-    util::{get_first_day_from_month, get_last_day_from_month},
+    schema::{Expense, ExpenseType, GetExpense, UpdateExpense},
+    util::{get_first_day_from_month_or_none, get_last_day_from_month_or_none},
     AppState, ExpensesTemplate,
 };
 use std::sync::Arc;
@@ -11,7 +11,7 @@ use axum::{
     extract::{Path, Query, State},
     response::Html,
     routing::get,
-    Router,
+    Json, Router,
 };
 
 pub fn hypermedia_router() -> Router<Arc<AppState>> {
@@ -32,30 +32,46 @@ pub async fn get_expenses(
     State(shared_state): State<Arc<AppState>>,
     Query(get_expense_input): Query<GetExpense>,
 ) -> impl IntoResponse {
-    let expenses: Vec<Expense> = match get_expense_input.month {
-        Some(month) => {
-            sqlx::query_as!(
-                Expense,
-                r#"SELECT id, description, price, expense_type as "expense_type: ExpenseType", is_essencial, date
-                FROM expenses WHERE date BETWEEN $1 AND $2 ORDER BY date ASC"#,
-                get_first_day_from_month(month.clone() as u32 + 1),
-                get_last_day_from_month(month as u32 + 1)
-            )
-            .fetch_all(&shared_state.pool)
-            .await
-            .unwrap()
-        }
-        None => {
-            sqlx::query_as!(
-                Expense,
-                r#"SELECT id, description, price, expense_type as "expense_type: ExpenseType", is_essencial, date
-                FROM expenses ORDER BY date ASC"#
-            )
-                .fetch_all(&shared_state.pool)
-                .await
-                .unwrap()
-        }
-    };
+    //let expenses: Vec<Expense> = match get_expense_input.month.clone() {
+    //    Some(month) => {
+    //        sqlx::query_as!(
+    //            Expense,
+    //            r#"SELECT id, description, price, expense_type as "expense_type: ExpenseType", is_essencial, date
+    //            FROM expenses WHERE date BETWEEN $1 AND $2 ORDER BY date ASC"#,
+    //            get_first_day_from_month(month.clone() as u32 + 1),
+    //            get_last_day_from_month(month as u32 + 1)
+    //        )
+    //        .fetch_all(&shared_state.pool)
+    //        .await
+    //        .unwrap()
+    //    }
+    //    None => {
+    //        sqlx::query_as!(
+    //            Expense,
+    //            r#"SELECT id, description, price, expense_type as "expense_type: ExpenseType", is_essencial, date
+    //            FROM expenses ORDER BY date ASC"#
+    //        )
+    //            .fetch_all(&shared_state.pool)
+    //            .await
+    //            .unwrap()
+    //    }
+    //};
+
+    let expenses = sqlx::query_as!(
+        Expense,
+        r#"SELECT id, description, price, expense_type as "expense_type: ExpenseType", is_essencial, date
+        FROM expenses
+        WHERE ((date >= $1) OR ($1 IS NULL))
+        AND ((date <= $2) OR ($2 IS NULL))
+        ORDER BY date ASC"#,
+        get_first_day_from_month_or_none(get_expense_input.month.clone()),
+        get_last_day_from_month_or_none(get_expense_input.month)
+    )
+    .fetch_all(&shared_state.pool)
+    .await
+    .unwrap();
+
+    tracing::info!("expenses: {:?}", expenses);
 
     Html(
         expenses
@@ -80,8 +96,12 @@ pub async fn edit_expense(
     Path(id): Path<i32>,
     State(shared_state): State<Arc<AppState>>,
 ) -> impl IntoResponse {
-    let expense: Expense = sqlx::query_as("SELECT * FROM expenses WHERE id = $1")
-        .bind(id)
+    let expense = sqlx::query_as!(
+        Expense,
+        r#"SELECT id, description, price, expense_type as "expense_type: ExpenseType", is_essencial, date
+        FROM expenses WHERE id = $1"#,
+        id
+    )
         .fetch_one(&shared_state.pool)
         .await
         .unwrap();
@@ -102,11 +122,15 @@ pub async fn get_expense(
     Path(id): Path<i32>,
     State(shared_state): State<Arc<AppState>>,
 ) -> impl IntoResponse {
-    let expense: Expense = sqlx::query_as("SELECT * FROM expenses WHERE id = $1")
-        .bind(id)
-        .fetch_one(&shared_state.pool)
-        .await
-        .unwrap();
+    let expense = sqlx::query_as!(
+        Expense,
+        r#"SELECT id, description, price, expense_type as "expense_type: ExpenseType", is_essencial, date
+        FROM expenses WHERE id = $1"#,
+        id
+    )
+    .fetch_one(&shared_state.pool)
+    .await
+    .unwrap();
 
     Html(format!(
         TABLE_ROW!(),
@@ -122,12 +146,30 @@ pub async fn get_expense(
 pub async fn update_expense(
     Path(id): Path<i32>,
     State(shared_state): State<Arc<AppState>>,
+    Json(update_expense): Json<UpdateExpense>,
 ) -> impl IntoResponse {
-    let expense: Expense = sqlx::query_as("SELECT * FROM expenses WHERE id = $1")
-        .bind(id)
-        .fetch_one(&shared_state.pool)
-        .await
-        .unwrap();
+    let expense = sqlx::query_as!(
+        Expense,
+        r#"
+        UPDATE expenses SET
+            description = COALESCE($1, description),
+            price = COALESCE($2, price),
+            expense_type = COALESCE($3 :: expense_type, expense_type),
+            is_essencial = COALESCE($4, is_essencial),
+            date = COALESCE($5, date)
+        WHERE id = $6
+        RETURNING id, description, price, expense_type as "expense_type: ExpenseType", is_essencial, date
+        "#,
+        update_expense.description,
+        update_expense.price,
+        update_expense.expense_type as Option<ExpenseType>,
+        update_expense.is_essencial,
+        update_expense.date,
+        id
+    )
+    .fetch_one(&shared_state.pool)
+    .await
+    .unwrap();
 
     Html(format!(
         TABLE_ROW!(),

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,7 @@
 use chrono::{Datelike, NaiveDate, Utc};
 
+use crate::data::Months;
+
 pub fn get_first_day_from_month(month: u32) -> NaiveDate {
     Utc::now()
         .with_day(1)
@@ -10,6 +12,17 @@ pub fn get_first_day_from_month(month: u32) -> NaiveDate {
         .unwrap()
 }
 
+pub fn get_first_day_from_month_or_none(month: Option<Months>) -> Option<NaiveDate> {
+    match month {
+        Some(month) => {
+            let day = Some(get_first_day_from_month(month as u32 + 1));
+            tracing::info!("first day: {:?}", day);
+            day
+        }
+        None => None,
+    }
+}
+
 pub fn get_last_day_from_month(month: u32) -> NaiveDate {
     let first_day_of_month = get_first_day_from_month(month);
 
@@ -17,4 +30,15 @@ pub fn get_last_day_from_month(month: u32) -> NaiveDate {
         return first_day_of_month.with_day(31).unwrap();
     }
     first_day_of_month.with_month(month + 1).unwrap() - chrono::Duration::days(1)
+}
+
+pub fn get_last_day_from_month_or_none(month: Option<Months>) -> Option<NaiveDate> {
+    match month {
+        Some(month) => {
+            let day = Some(get_last_day_from_month(month as u32 + 1));
+            tracing::info!("last day: {:?}", day);
+            day
+        }
+        None => None,
+    }
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -30,6 +30,7 @@
             })
         </script>
         <script src="https://unpkg.com/htmx.org/dist/ext/response-targets.js"></script>
+        <script src="https://unpkg.com/htmx.org/dist/ext/json-enc.js"></script>
         <script src="https://unpkg.com/hyperscript.org@0.9.12"></script>
 
         <!-- Allow any inheriting page to extend head with additional assets -->

--- a/templates/expenses.html
+++ b/templates/expenses.html
@@ -16,7 +16,7 @@
                 <option value="{{ month }}">{{ month }}</option>
             {% endif %}
         {% endfor %}
-        <option>Entire year</option>
+        <option value="">Entire year</option>
     </select>
 
     <button type="submit">Search</button>


### PR DESCRIPTION
Now updating expenses is fixed in the table overview.

Some notes:
- We cant create an expense in the site yet
- Also, no values can be null, so sending them blank in update, simply doesn't affect them at all. This could be confusing for the user.

Run migrations!