### PR TITLE
fix: csp headers fix and add to every request as most strict as possible

### DIFF
--- a/.sqlx/query-5d8431eae879875acc19bda5152109f4bcfdb87ac806a6c834ffe11829e9d1d5.json
+++ b/.sqlx/query-5d8431eae879875acc19bda5152109f4bcfdb87ac806a6c834ffe11829e9d1d5.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT EXISTS(SELECT 1 FROM users WHERE email = $1 AND verified = true)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "5d8431eae879875acc19bda5152109f4bcfdb87ac806a6c834ffe11829e9d1d5"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1965,6 +1965,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2731,9 +2737,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.30"
+version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
  "bitflags 2.4.2",
  "errno",
@@ -3650,12 +3656,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
+checksum = "fe80ced77cbfb4cb91a94bf72b378b4b6791a0d9b7f09d0be747d1bdff4e68bd"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
  "powerfmt",
  "serde",
  "time-core",
@@ -3670,10 +3677,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,12 +683,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+checksum = "da01daa5f6d41c91358398e8db4dde38e292378da1f28300b59ef4732b879454"
 dependencies = [
- "darling_core 0.20.3",
- "darling_macro 0.20.3",
+ "darling_core 0.20.4",
+ "darling_macro 0.20.4",
 ]
 
 [[package]]
@@ -707,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+checksum = "f44f6238b948a3c6c3073cdf53bb0c2d5e024ee27e0f35bfe9d556a12395808a"
 dependencies = [
  "fnv",
  "ident_case",
@@ -732,11 +732,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+checksum = "0d2d88bd93979b1feb760a6b5c531ac5ba06bd63e74894c377af02faee07b9cd"
 dependencies = [
- "darling_core 0.20.3",
+ "darling_core 0.20.4",
  "quote",
  "syn 2.0.48",
 ]
@@ -1658,9 +1658,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -2946,7 +2946,7 @@ version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
 dependencies = [
- "darling 0.20.3",
+ "darling 0.20.4",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -3239,7 +3239,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce81b7bd7c4493975347ef60d8c7e8b742d4694f4c49f93e0a12ea263938176c"
 dependencies = [
- "itertools 0.12.0",
+ "itertools 0.12.1",
  "nom",
  "unicode_categories",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,12 +683,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.4"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da01daa5f6d41c91358398e8db4dde38e292378da1f28300b59ef4732b879454"
+checksum = "fc5d6b04b3fd0ba9926f945895de7d806260a2d7431ba82e7edaecb043c4c6b8"
 dependencies = [
- "darling_core 0.20.4",
- "darling_macro 0.20.4",
+ "darling_core 0.20.5",
+ "darling_macro 0.20.5",
 ]
 
 [[package]]
@@ -707,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.4"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f44f6238b948a3c6c3073cdf53bb0c2d5e024ee27e0f35bfe9d556a12395808a"
+checksum = "04e48a959bcd5c761246f5d090ebc2fbf7b9cd527a492b07a67510c108f1e7e3"
 dependencies = [
  "fnv",
  "ident_case",
@@ -732,11 +732,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.4"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d2d88bd93979b1feb760a6b5c531ac5ba06bd63e74894c377af02faee07b9cd"
+checksum = "1d1545d67a2149e1d93b7e5c7752dce5a7426eb5d1357ddcfd89336b94444f77"
 dependencies = [
- "darling_core 0.20.4",
+ "darling_core 0.20.5",
  "quote",
  "syn 2.0.48",
 ]
@@ -1214,7 +1214,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.11",
- "indexmap 2.2.1",
+ "indexmap 2.2.2",
  "slab",
  "tokio",
  "tokio-util",
@@ -1233,7 +1233,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 1.0.0",
- "indexmap 2.2.1",
+ "indexmap 2.2.2",
  "slab",
  "tokio",
  "tokio-util",
@@ -1527,12 +1527,11 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdea9aac0dbe5a9240d68cfd9501e2db94222c6dc06843e06640b9e07f0fdc67"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
 dependencies = [
  "bytes",
- "futures-channel",
  "futures-util",
  "http 1.0.0",
  "http-body 1.0.0",
@@ -1540,7 +1539,6 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -1624,9 +1622,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433de089bd45971eecf4668ee0ee8f4cec17db4f8bd8f7bc3197a6ce37aa7d9b"
+checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -1731,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libm"
@@ -2074,7 +2072,7 @@ checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
 dependencies = [
  "futures-core",
  "futures-sink",
- "indexmap 2.2.1",
+ "indexmap 2.2.2",
  "js-sys",
  "once_cell",
  "pin-project-lite",
@@ -2621,9 +2619,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.23"
+version = "0.11.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
+checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -2649,6 +2647,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sync_wrapper",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -2946,7 +2945,7 @@ version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
 dependencies = [
- "darling 0.20.4",
+ "darling 0.20.5",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -3280,7 +3279,7 @@ dependencies = [
  "futures-util",
  "hashlink",
  "hex",
- "indexmap 2.2.1",
+ "indexmap 2.2.2",
  "log",
  "memchr",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ shuttle-secrets = "0.37.0"
 shuttle-shared-db = { version = "0.37.0", features = ["postgres", "sqlx"] }
 sqlx = { version = "0.7.3", features = ["runtime-tokio-rustls", "postgres", "chrono"] }
 strum = { version = "0.26.1", features = ["strum_macros", "derive"] }
-time = "0.3.31"
+time = "0.3.32"
 tokio = { version = "1.35.1", features = ["full"] }
 totp-rs = { version = "5.4.0", features = ["qr"] }
 tower = "0.4.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ password-auth = "1.0.0"
 plotly = { git = "https://github.com/nicolasauler/plotly.git" }
 rand = "0.8.5"
 regex = "1.10.2"
-reqwest = { version = "0.11.23", features = ["json"] }
+reqwest = { version = "0.11.24", features = ["json"] }
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = "1.0.113"
 shuttle-axum = "0.37.0"

--- a/README.md
+++ b/README.md
@@ -34,13 +34,14 @@ and uses `#![forbid(unsafe_code)]` to ensure everything is implemented in 100% s
 
 Current security status:
 - [x] Basic stuff: redacted password in inputs, completion from browser
-- [x] Password strengh validation and enforcement
-- [x] Password encryption with Argon2
+- [x] Password strengh validation and enforcement, encryption with Argon2
 - [x] Expiring sessions
 - [x] Email confirmation
 - [x] Secure Multi-Factor Authentication (no SMS or email)
+- [x] Captcha and Rate limiting
+- [x] HTTP sec headers
+- [ ] CSP [#72](https://github.com/nicolasauler/finnish/pull/72)
 - [ ] MFA sessions and management
-- [ ] Captcha and spam avoidance
 
 Current financial features status:
 - [x] Basic expenses managing (manual insert, editing and removal)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Current security status:
 - [x] Secure Multi-Factor Authentication (no SMS or email)
 - [x] Captcha and Rate limiting
 - [x] HTTP sec headers
-- [ ] CSP [#72](https://github.com/nicolasauler/finnish/pull/72)
+- [x] CSP
 - [ ] MFA sessions and management
 
 Current financial features status:

--- a/js/disable-button-oncaptcha.js
+++ b/js/disable-button-oncaptcha.js
@@ -1,0 +1,3 @@
+function onCaptcha(solution) {
+    document.getElementById('submit-button').disabled = false;
+}

--- a/js/functions._hs
+++ b/js/functions._hs
@@ -1,0 +1,13 @@
+def onCaptcha(solution)
+    if solution
+        document.getElementById('form-button-submit').removeAttribute('disabled')
+    else
+        document.getElementById('form-button-submit').setAttribute('disabled', '')
+    end
+end
+
+def resetCaptcha()
+    friendlyChallenge.autoWidget.reset()
+    finally
+        add @disabled to #form-button-submit
+end

--- a/src/hypermedia/router/auth.rs
+++ b/src/hypermedia/router/auth.rs
@@ -2,7 +2,7 @@ use crate::{
     auth::{AuthSession, LoginCredentials},
     hypermedia::schema::{
         auth::MfaTokenForm,
-        validation::{ChangePasswordInput, SignUpInput},
+        validation::{ChangePasswordInput, ResendEmail, SignUpInput},
     },
     templates::ChangePasswordTemplate,
     AppState,
@@ -95,13 +95,6 @@ async fn signup(
     .await
 }
 
-#[derive(serde::Deserialize)]
-pub struct ResendEmail {
-    pub email: String,
-    #[serde(rename = "frc-captcha-solution")]
-    pub frc_captcha_solution: String,
-}
-
 async fn resend_verification_email(
     State(shared_state): State<Arc<AppState>>,
     Form(resend_email): Form<ResendEmail>,
@@ -118,7 +111,12 @@ async fn verify_email(
     State(shared_state): State<Arc<AppState>>,
     Path(token): Path<String>,
 ) -> impl IntoResponse {
-    crate::hypermedia::service::auth::verify_email(&shared_state.pool, token).await
+    crate::hypermedia::service::auth::verify_email(
+        &shared_state.pool,
+        &shared_state.secret_store,
+        token,
+    )
+    .await
 }
 
 async fn forgot_password() -> impl IntoResponse {

--- a/src/hypermedia/router/auth.rs
+++ b/src/hypermedia/router/auth.rs
@@ -131,11 +131,13 @@ async fn logout(auth_session: AuthSession) -> impl IntoResponse {
 }
 
 async fn change_password_screen() -> impl IntoResponse {
-    ChangePasswordTemplate {
+    return ChangePasswordTemplate {
         change_password: "/auth/change-password".to_owned(),
         passwords_match: "/validate/new-passwords".to_owned(),
         password_strength: "/validate/new-password-strength".to_owned(),
+        ..Default::default()
     }
+    .into_response_with_nonce();
 }
 
 async fn change_password(

--- a/src/hypermedia/router/expenses.rs
+++ b/src/hypermedia/router/expenses.rs
@@ -30,10 +30,10 @@ pub fn router() -> Router<Arc<AppState>> {
 async fn expenses_index(auth_session: AuthSession) -> impl IntoResponse {
     match auth_session.user {
         Some(user) => ExpensesTemplate {
-            username: &user.username,
+            username: user.username.clone(),
             ..Default::default()
         }
-        .into_response(),
+        .into_response_with_nonce(),
         None => StatusCode::UNAUTHORIZED.into_response(),
     }
 }

--- a/src/hypermedia/router/expenses.rs
+++ b/src/hypermedia/router/expenses.rs
@@ -30,7 +30,7 @@ pub fn router() -> Router<Arc<AppState>> {
 async fn expenses_index(auth_session: AuthSession) -> impl IntoResponse {
     match auth_session.user {
         Some(user) => ExpensesTemplate {
-            username: user.username.clone(),
+            username: user.username,
             ..Default::default()
         }
         .into_response_with_nonce(),

--- a/src/hypermedia/schema/validation.rs
+++ b/src/hypermedia/schema/validation.rs
@@ -67,3 +67,11 @@ pub struct ChangePasswordInput {
 pub struct Exists {
     pub exists: Option<bool>,
 }
+
+#[derive(Deserialize, Validate)]
+pub struct ResendEmail {
+    #[validate(email)]
+    pub email: String,
+    #[serde(rename = "frc-captcha-solution")]
+    pub frc_captcha_solution: String,
+}

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -41,8 +41,8 @@ impl Default for ExpensesTemplate {
             },
             expense_categories: ExpenseCategory::iter(),
             months: Months::iter(),
-            username: "".to_owned(),
-            nonce: "".to_owned(),
+            username: String::new(),
+            nonce: String::new(),
         };
     }
 }
@@ -52,7 +52,7 @@ impl ExpensesTemplate {
         let nonce = generate_otp_token();
         let nonce_str = format!("'nonce-{nonce}'");
 
-        let mut response = ExpensesTemplate {
+        let mut response = Self {
             current_month: self.current_month,
             expense_categories: self.expense_categories,
             months: self.months,
@@ -85,7 +85,7 @@ impl ChangePasswordTemplate {
         let nonce = generate_otp_token();
         let nonce_str = format!("'nonce-{nonce}'");
 
-        let mut response = ChangePasswordTemplate {
+        let mut response = Self {
             change_password: self.change_password,
             passwords_match: self.passwords_match,
             password_strength: self.password_strength,
@@ -115,7 +115,7 @@ impl SignInTemplate {
         let nonce = generate_otp_token();
         let nonce_str = format!("'nonce-{nonce}'");
 
-        let mut response = SignInTemplate {
+        let mut response = Self {
             message: self.message,
             frc_sitekey: self.frc_sitekey,
             nonce,
@@ -142,7 +142,7 @@ impl SignUpTemplate {
         let nonce = generate_otp_token();
         let nonce_str = format!("'nonce-{nonce}'");
 
-        let mut response = SignUpTemplate {
+        let mut response = Self {
             frc_sitekey: self.frc_sitekey,
             nonce,
         }
@@ -168,6 +168,8 @@ pub struct VerificationTemplate {
     pub should_print_resend_link: bool,
     /// CSP nonce
     pub nonce: String,
+    /// Friendly captcha secret key for getting the captcha problem
+    pub frc_sitekey: String,
 }
 
 #[derive(Template, Default)]
@@ -192,7 +194,7 @@ impl MfaTemplate {
         let nonce = generate_otp_token();
         let nonce_str = format!("'nonce-{nonce}'");
 
-        let mut response = MfaTemplate {
+        let mut response = Self {
             mfa_url: self.mfa_url,
             qr_code: self.qr_code,
             otp_auth_url: self.otp_auth_url,
@@ -223,7 +225,7 @@ impl ConfirmationTemplate {
         let nonce = generate_otp_token();
         let nonce_str = format!("'nonce-{nonce}'");
 
-        let mut response = ConfirmationTemplate {
+        let mut response = Self {
             resend_url: self.resend_url,
             login_url: self.login_url,
             frc_sitekey: self.frc_sitekey,

--- a/src/util.rs
+++ b/src/util.rs
@@ -105,5 +105,5 @@ pub fn add_csp_to_response(response: &mut Response<Body>, nonce_str: &str) {
     //let mut response = response.into_response();
     response
         .headers_mut()
-        .insert("Content-Security-Policy", csp.to_string().parse().unwrap());
+        .insert("content-security-policy", csp.to_string().parse().unwrap());
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,6 @@
 use crate::data_structs::Months;
 
-use askama_axum::IntoResponse;
+use axum::{body::Body, http::Response};
 use axum_helmet::ContentSecurityPolicy;
 use chrono::{Datelike, NaiveDate, Utc};
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
@@ -87,7 +87,7 @@ pub fn now_plus_24_hours() -> Option<chrono::DateTime<chrono::Utc>> {
 }
 
 /// Receives something that implements `IntoResponse` and adds a CSP header to it.
-pub fn add_csp_to_response(response: impl IntoResponse, nonce_str: &str) -> impl IntoResponse {
+pub fn add_csp_to_response(response: &mut Response<Body>, nonce_str: &str) {
     let csp = ContentSecurityPolicy::new()
         .default_src(vec!["'self'", "https://api.friendlycaptcha.com"])
         .base_uri(vec!["'none'"])
@@ -95,17 +95,15 @@ pub fn add_csp_to_response(response: impl IntoResponse, nonce_str: &str) -> impl
         .form_action(vec!["'none'"])
         .frame_src(vec!["'none'"])
         .frame_ancestors(vec!["'none'"])
-        .img_src(vec!["'self'"])
+        .img_src(vec!["'self'", "data:"])
         .object_src(vec!["'none'"])
-        .script_src(vec!["'strict-dynamic'", nonce_str])
-        .style_src(vec!["'self'"])
+        .script_src(vec!["'wasm-unsafe-eval'", "'strict-dynamic'", nonce_str])
+        .style_src(vec!["'self'", "https:", "'unsafe-inline'"])
         .worker_src(vec!["blob:"])
         .upgrade_insecure_requests();
 
-    let mut response = response.into_response();
+    //let mut response = response.into_response();
     response
         .headers_mut()
         .insert("Content-Security-Policy", csp.to_string().parse().unwrap());
-
-    return response;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,8 +5,7 @@
 
         <link nonce="{% block nonce %}{{ nonce }}{% endblock %}" rel="stylesheet" href="/static/pico.min.css">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <script nonce="{% block nonce %}{{ nonce }}{% endblock %}"
-            src="/js/htmx.min.js"></script>
+        <script nonce="{% block nonce %}{{ nonce }}{% endblock %}" src="/js/htmx.min.js"></script>
 
         {% block head %}{% endblock %}
     </head>

--- a/templates/change_password.html
+++ b/templates/change_password.html
@@ -1,12 +1,12 @@
 {% extends "base_logged_in.html" %}
 
-{% block nonce %}Nonce{% endblock %}
+{% block title %}Auth{% endblock %}
+
+{% block nonce %}{{ nonce }}{% endblock %}
 
 {% block head %}
-<script src="/js/response-targets.js"></script>
+<script nonce="{{ nonce }}" src="/js/response-targets.js"></script>
 {% endblock %}
-
-{% block title %}Auth{% endblock %}
 
 {% block content %}
 

--- a/templates/confirmation.html
+++ b/templates/confirmation.html
@@ -3,6 +3,8 @@
 {% block nonce %}{{ nonce }}{% endblock %}
 
 {% block head %}
+<script nonce="{{ nonce }}" type="text/hyperscript" src="/js/functions._hs"></script>
+<script nonce="{{ nonce }}" src="/js/hyperscript.min.js"></script>
 <script nonce="{{ nonce }}" src="/js/response-targets.js"></script>
 <script
   nonce="{{ nonce }}"
@@ -22,7 +24,7 @@
     <div id="return-from-signup">
         <p>
             Thank you for signing up.
-            Please Check your email.
+            Please check your email.
             Instructions on how to proceed have been sent to you.
         </p>
     </div>
@@ -31,9 +33,24 @@
         <p>
             If you did not receive the email, you can request a new one.
         </p>
-        <form hx-post="{{ resend_url }}" hx-target="#resend-confirmation-response">
-            <input type="text" name="email" placeholder="Email" required />
-            <button id="submit-resend-button" type="submit" disabled>Resend Confirmation Email</button>
+        <form hx-post="{{ resend_url }}" hx-target="#resend-confirmation-response" hx-target-error="#resend-confirmation-response" _="on htmx:afterOnLoad call resetCaptcha()">
+            <div hx-target="this" hx-swap="outerHTML">
+                <div class="grid">
+                <img id="ind" src="/img/bars.svg" class="htmx-indicator"/>
+                </div>
+                <input
+                  type="email"
+                  name="email"
+                  placeholder="email@server.com"
+                  aria-label="Email"
+                  autocomplete="email"
+                  hx-post="/validate/email"
+                  hx-sync="closest form:abort"
+                  hx-indicator="#ind"
+                  required
+                />
+            </div>
+            <button id="form-button-submit" type="submit" disabled>Resend Confirmation Email</button>
             <div class="frc-captcha" data-sitekey="{{ frc_sitekey }}" data-callback="onCaptcha"></div>
         </form>
 
@@ -42,11 +59,5 @@
 
     <footer><a href="{{ login_url }}">Go To Login Page</a></footer>
 </article>
-
-<script>
-    function onCaptcha(solution) {
-        document.getElementById('submit-resend-button').disabled = false;
-    }
-</script>
 
 {% endblock %}

--- a/templates/confirmation.html
+++ b/templates/confirmation.html
@@ -1,14 +1,15 @@
 {% extends "base.html" %}
 
-{% block nonce %}Nonce{% endblock %}
+{% block nonce %}{{ nonce }}{% endblock %}
 
 {% block head %}
-<script src="/js/response-targets.js"></script>
+<script nonce="{{ nonce }}" src="/js/response-targets.js"></script>
 <script
+  nonce="{{ nonce }}"
   type="module"
   src="/js/widget.module.min.js"
 ></script>
-<script nomodule src="/js/widget.min.js" ></script>
+<script nonce="{{ nonce }}" nomodule src="/js/widget.min.js" ></script>
 {% endblock %}
 
 {% block title %}Email Confirmation{% endblock %}

--- a/templates/expenses.html
+++ b/templates/expenses.html
@@ -2,11 +2,11 @@
 
 {% block title %}Expenses{% endblock %}
 
-{% block nonce %}Nonce{% endblock %}
+{% block nonce %}{{ nonce }}{% endblock %}
 
 {% block head %}
-<script src="/js/hyperscript.min.js"></script>
-<script src="/js/plotly-strict-2.28.0.min.js" charset="utf-8"></script>
+<script nonce="{{ nonce }}" src="/js/hyperscript.min.js"></script>
+<script nonce="{{ nonce }}" src="/js/plotly-strict-2.28.0.min.js" charset="utf-8"></script>
 {% endblock %}
 
 {% block content %}

--- a/templates/mfa.html
+++ b/templates/mfa.html
@@ -2,7 +2,7 @@
 
 {% block title %}Authentication{% endblock %}
 
-{% block nonce %}Nonce{% endblock %}
+{% block nonce %}{{ nonce }}{% endblock %}
 
 {% block content %}
 

--- a/templates/signin.html
+++ b/templates/signin.html
@@ -5,6 +5,7 @@
 {% block nonce %}{{ nonce }}{% endblock %}
 
 {% block head %}
+<script nonce="{{ nonce }}" type="text/hyperscript" src="/js/functions._hs"></script>
 <script nonce="{{ nonce }}" src="/js/hyperscript.min.js"></script>
 <script nonce="{{ nonce }}" src="/js/response-targets.js"></script>
 <script
@@ -33,7 +34,7 @@
     </div>
 
     <div id="tab-content" role="tabpanel" class="tab-content">
-        <form id="signin-form" hx-post="/auth/signin" hx-target="#signin-article" hx-target-error="#message">
+        <form id="signin-form" hx-post="/auth/signin" hx-target="#signin-article" hx-target-error="#message" _="on htmx:afterOnLoad call resetCaptcha()">
             <input
               type="text"
               name="email"
@@ -50,7 +51,7 @@
               autocomplete="current-password"
               required
             />
-            <button type="submit" class="contrast" disabled>Login</button>
+            <button id="form-button-submit" type="submit" class="contrast" disabled>Login</button>
             <fieldset>
                 <label for="remember">
                     <input type="checkbox" role="switch" id="remember" name="remember" />
@@ -62,15 +63,5 @@
         <div id="message">{{ message }}</div>
     </div>
 </article>
-
-<script type="text/hyperscript">
-    def onCaptcha(solution)
-        if solution
-            document.querySelector('#signin-form button').removeAttribute('disabled')
-        else
-            document.querySelector('#signin-form button').setAttribute('disabled', '')
-        end
-    end
-</script>
 
 {% endblock %}

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -5,6 +5,7 @@
 {% block nonce %}{{ nonce }}{% endblock %}
 
 {% block head %}
+<script nonce="{{ nonce }}" src="/js/disable-button-oncaptcha.js"></script>
 <script
   nonce="{{ nonce }}"
   type="module"
@@ -104,16 +105,10 @@
                   required
                 />
             </div>
-            <button id="submit-signup-button" type="submit" class="contrast" disabled>Sign up</button>
+            <button id="submit-button" type="submit" class="contrast" disabled>Sign up</button>
             <div class="frc-captcha" data-sitekey="{{ frc_sitekey }}" data-callback="onCaptcha"></div>
         </form>
     </div>
 </article>
-
-<script nonce="{{ nonce }}">
-    function onCaptcha(solution) {
-        document.getElementById('submit-signup-button').disabled = false;
-    }
-</script>
 
 {% endblock %}

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -1,16 +1,17 @@
 {% extends "base.html" %}
 
-{% block nonce %}Nonce{% endblock %}
+{% block title %}Auth{% endblock %}
+
+{% block nonce %}{{ nonce }}{% endblock %}
 
 {% block head %}
 <script
+  nonce="{{ nonce }}"
   type="module"
   src="/js/widget.module.min.js"
 ></script>
-<script nomodule src="/js/widget.min.js" ></script>
+<script nonce="{{ nonce }}" nomodule src="/js/widget.min.js" ></script>
 {% endblock %}
-
-{% block title %}Auth{% endblock %}
 
 {% block content %}
 
@@ -109,7 +110,7 @@
     </div>
 </article>
 
-<script>
+<script nonce="{{ nonce }}">
     function onCaptcha(solution) {
         document.getElementById('submit-signup-button').disabled = false;
     }

--- a/templates/verify.html
+++ b/templates/verify.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block nonce %}Nonce{% endblock %}
+{% block nonce %}{{ nonce }}{% endblock %}
 
 {% block title %}Email Confirmation{% endblock %}
 

--- a/templates/verify.html
+++ b/templates/verify.html
@@ -2,6 +2,16 @@
 
 {% block nonce %}{{ nonce }}{% endblock %}
 
+{% block head %}
+<script nonce="{{ nonce }}" src="/js/disable-button-oncaptcha.js"></script>
+<script
+  nonce="{{ nonce }}"
+  type="module"
+  src="/js/widget.module.min.js"
+></script>
+<script nonce="{{ nonce }}" nomodule src="/js/widget.min.js" ></script>
+{% endblock %}
+
 {% block title %}Email Confirmation{% endblock %}
 
 {% block content %}
@@ -15,10 +25,16 @@
 
     {% if should_print_resend_link %}
         <div id="resend-confirmation">
-            <form hx-get="{{ resend_url }}">
-                <input type="text" name="username" placeholder="Username"/>
-                <button type="submit">Resend Confirmation Email</button>
+            <p>
+                If you did not receive the email, you can request a new one.
+            </p>
+            <form hx-post="{{ resend_url }}" hx-target="#resend-confirmation-response">
+                <input type="text" name="email" placeholder="Email" required />
+                <button id="submit-button" type="submit" disabled>Resend Confirmation Email</button>
+                <div class="frc-captcha" data-sitekey="{{ frc_sitekey }}" data-callback="onCaptcha"></div>
             </form>
+
+            <div id="resend-confirmation-response"></div>
         </div>
     {% endif %}
 


### PR DESCRIPTION
After #64 was merged, csp headers were removed from helmet layer, so that nonces could be set for every request.
This PR sets up CSP for every funcionality, with those nonces.

Closes #29 
Closes #71 


Tried to follow https://docs.friendlycaptcha.com/#/csp for allowing Friendly Captcha.
Also this for strict CSP:
- https://content-security-policy.com/nonce/
- https://content-security-policy.com/strict-dynamic/
- https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html
- https://web.dev/articles/strict-csp

Followed these for writing default CSP middleware:
- https://docs.rs/axum/latest/axum/middleware/index.html
- https://users.rust-lang.org/t/axum-problem-trying-to-set-multiple-headers-with-same-name/78781
- https://docs.rs/tower/0.4.13/tower/trait.ServiceExt.html#method.map_response