### PR TITLE
feat: adding data api expenses services

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,6 @@ updates, before adding idk, a new plot in the expenses or income page.
 
 ### Install pre-commit
 ```shell
-curl -LO https://github.com/pre-commit/pre-commit/releases/download/v3.7.0/pre-commit-3.7.0.pyz
-python pre-commit-3.7.0.pyz install
+curl -LO https://github.com/pre-commit/pre-commit/releases/download/v3.7.1/pre-commit-3.7.1.pyz
+python pre-commit-3.7.1.pyz install
 ```

--- a/api.http
+++ b/api.http
@@ -1,0 +1,41 @@
+# Add Expense
+## Request
+curl 'http://127.0.0.1:8000/api/expenses' -X POST -H 'Cookie: id=<secret_token>' -H 'Content-Type: application/json' --data-raw '{ "date": "2024-05-26", "price": "4.20", "description": "fromapi", "category": "Food", "is_essential": "true" }'
+
+## Response
+{"id":3,"description":"fromapi","price":4.2,"category":"Food","is_essential":true,"date":"2024-05-26","uuid":"7369ae06-0e51-42f5-b671-f2a8813a7a13"}
+
+# Get Expenses
+## Request
+curl 'http://127.0.0.1:8000/api/expenses?month=May' -H 'Cookie: id=<secret_token>'
+
+## Response
+[
+  {
+    "id": 1,
+    "description": "asdfasdf",
+    "price": -0.03,
+    "category": "Food",
+    "is_essential": false,
+    "date": "2024-05-19",
+    "uuid": "7d2597c8-0ecb-4da1-9e2e-6762ce620119"
+  },
+  {
+    "id": 2,
+    "description": "whatever",
+    "price": 1.65,
+    "category": "Food",
+    "is_essential": true,
+    "date": "2024-05-26",
+    "uuid": "ad3b1e10-01e3-40b1-a9e1-7f3f63aac93b"
+  },
+  {
+    "id": 3,
+    "description": "fromapi",
+    "price": 4.2,
+    "category": "Food",
+    "is_essential": true,
+    "date": "2024-05-26",
+    "uuid": "7369ae06-0e51-42f5-b671-f2a8813a7a13"
+  }
+]

--- a/api.http
+++ b/api.http
@@ -39,3 +39,41 @@ curl 'http://127.0.0.1:8000/api/expenses?month=May' -H 'Cookie: id=<secret_token
     "uuid": "7369ae06-0e51-42f5-b671-f2a8813a7a13"
   }
 ]
+
+# Get an Expense
+## Request
+curl 'http://127.0.0.1:8000/api/expenses/8098c51a-e112-48b7-a555-a329b95b784b' -H 'Cookie: id=<secret_token>'
+
+## Response
+{
+  "id": 2,
+  "description": "whatever",
+  "price": 1.65,
+  "category": "Food",
+  "is_essential": true,
+  "date": "2024-05-26",
+  "uuid": "ad3b1e10-01e3-40b1-a9e1-7f3f63aac93b"
+}
+
+# Update an Expense
+## Request
+curl 'http://127.0.0.1:8000/api/expenses/ad3b1e10-01e3-40b1-a9e1-7f3f63aac93b' -X PUT -H 'Cookie: id=VxsvrnlHkk81VxGBZN-VJg' -H 'Content-Type: application/json' --data-raw '{ "category": "Education" }'
+
+## Response
+{
+  "id": 2,
+  "description": "changed_from_api",
+  "price": 1.65,
+  "category": "Food",
+  "is_essential": false,
+  "date": "2024-05-26",
+  "uuid": "ad3b1e10-01e3-40b1-a9e1-7f3f63aac93b"
+}
+
+# Delete an Expense
+## Request
+curl 'http://127.0.0.1:8000/api/expenses/8098c51a-e112-48b7-a555-a329b95b784b' -X DELETE -H 'Cookie: id=<secret_token>'
+
+## Response
+### Status: 204 if ok
+### Status: 404 if not found

--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715961556,
-        "narHash": "sha256-+NpbZRCRisUHKQJZF3CT+xn14ZZQO+KjxIIanH3Pvn4=",
+        "lastModified": 1716137900,
+        "narHash": "sha256-sowPU+tLQv8GlqtVtsXioTKeaQvlMz/pefcdwg8MvfM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4a6b83b05df1a8bd7d99095ec4b4d271f2956b64",
+        "rev": "6c0b7a92c30122196a761b440ac0d46d3d9954f1",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1716085073,
-        "narHash": "sha256-3+9gI93XxszWA2+9S2xZfws1QArPX/MC6nahOGpcMB4=",
+        "lastModified": 1716171463,
+        "narHash": "sha256-lc7wOh5BjYUoxdhcPkeUY8BmuL2qtRaHlW1403RW48E=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "cfc8776011bd83508324115d353222475e1601c0",
+        "rev": "04d61d14803854fd8453ec43c5c53a471e5407a8",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,7 @@
             sqlx-cli
             shuttle
             postgresql
+            jq
           ];
 
           shellHook = ''

--- a/flake.nix
+++ b/flake.nix
@@ -56,8 +56,8 @@
           ];
 
           shellHook = ''
-            # export DATABASE_URL=postgres://postgres:postgres@localhost:17144/finnish
-            export DATABASE_URL=postgres://postgres:postgres@localhost:21372/finnish
+            export DATABASE_URL=postgres://postgres:postgres@localhost:17144/finnish
+            # export DATABASE_URL=postgres://postgres:postgres@localhost:21372/finnish
           '';
           # shellHook = ''
           #   alias ls=eza

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,8 @@
           };
           # cargoHash = "";
         };
+        # rust = pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.default);
+        rust = pkgs.rust-bin.beta.latest.default;
         overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs {
           inherit system overlays;
@@ -47,13 +49,15 @@
             openssl
             pkg-config
             python3
-            rust-bin.beta.latest.default
+            rust
             sqlx-cli
             shuttle
+            postgresql
           ];
 
           shellHook = ''
-            export DATABASE_URL=postgres://postgres:postgres@localhost:17144/finnish
+            # export DATABASE_URL=postgres://postgres:postgres@localhost:17144/finnish
+            export DATABASE_URL=postgres://postgres:postgres@localhost:21372/finnish
           '';
           # shellHook = ''
           #   alias ls=eza

--- a/migrations/0003_add-uuid-constraint-to-expenses.sql
+++ b/migrations/0003_add-uuid-constraint-to-expenses.sql
@@ -1,0 +1,2 @@
+ALTER TABLE expenses
+ADD CONSTRAINT expenses_uuid_key UNIQUE (uuid);

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -127,7 +127,7 @@ pub struct Permission {
 impl From<&str> for Permission {
     fn from(name: &str) -> Self {
         Self {
-            name: name.to_string(),
+            name: name.to_owned(),
         }
     }
 }

--- a/src/data/router.rs
+++ b/src/data/router.rs
@@ -29,10 +29,15 @@ async fn get_expenses(
     .await
 }
 
-// async fn insert_expense(
-//     auth_session: AuthSession,
-//     State(shared_state): State<Arc<AppState>>,
-//     Json(create_expense): Json<UpdateExpense>,
-// ) -> Result<impl IntoResponse, impl IntoResponse> {
-//     super::service::create_expense(auth_session, &shared_state.pool, Json(create_expense)).await
-// }
+async fn insert_expense(
+    auth_session: AuthSession,
+    State(shared_state): State<Arc<AppState>>,
+    Json(create_expense): Json<UpdateExpense>,
+) -> impl IntoResponse {
+    crate::data::service::expenses::insert_expense(
+        auth_session,
+        &shared_state.pool,
+        create_expense,
+    )
+    .await
+}

--- a/src/data/router.rs
+++ b/src/data/router.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 
 use crate::{
     auth::AuthSession,
-    schema::{GetExpense, UpdateExpense},
+    schema::{GetExpense, UpdateExpense, UpdateExpenseApi},
     AppState,
 };
 
@@ -17,7 +17,7 @@ pub fn data_router() -> Router<Arc<AppState>> {
     Router::new()
         .route("/api/expenses", get(get_expenses).post(insert_expense))
         .route(
-            "/api/:uuid",
+            "/api/expenses/:uuid",
             get(get_expense).put(update_expense).delete(delete_expense),
         )
 }
@@ -56,7 +56,7 @@ async fn update_expense(
     auth_session: AuthSession,
     Path(uuid): Path<Uuid>,
     State(shared_state): State<Arc<AppState>>,
-    Json(update_expense): Json<UpdateExpense>,
+    Json(update_expense): Json<UpdateExpenseApi>,
 ) -> impl IntoResponse {
     crate::data::service::expenses::update_expense(
         auth_session,

--- a/src/data/router.rs
+++ b/src/data/router.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 pub fn data_router() -> Router<Arc<AppState>> {
-    Router::new().route("/api/expenses", get(get_expenses)) //.post(insert_expense))
+    Router::new().route("/api/expenses", get(get_expenses).post(insert_expense))
 }
 
 async fn get_expenses(
@@ -34,10 +34,6 @@ async fn insert_expense(
     State(shared_state): State<Arc<AppState>>,
     Json(create_expense): Json<UpdateExpense>,
 ) -> impl IntoResponse {
-    crate::data::service::expenses::insert_expense(
-        auth_session,
-        &shared_state.pool,
-        create_expense,
-    )
-    .await
+    crate::data::service::expenses::insert_expense(auth_session, &shared_state.pool, create_expense)
+        .await
 }

--- a/src/data/service/expenses.rs
+++ b/src/data/service/expenses.rs
@@ -59,32 +59,40 @@ pub async fn get_expenses(
     }
 }
 
-// pub async fn create_expense(
-//     auth_session: AuthSession,
-//     db_pool: &Pool<Postgres>,
-//     Json(create_expense): Json<UpdateExpense>,
-// ) -> Result<impl IntoResponse, impl IntoResponse> {
-//     let user_id = auth_session.user.expect("User should be authenticated").id;
-//     match sqlx::query_as!(
-//         Expense,
-//         r#"
-//         INSERT INTO expenses
-//         (description, price, category, is_essential, date, uuid, user_id)
-//         VALUES ($1, $2, $3 :: expense_category, $4, $5, $6, $7)
-//         RETURNING id, description, price, category as "category: ExpenseCategory", is_essential, date, uuid
-//         "#,
-//         create_expense.description,
-//         create_expense.price,
-//         create_expense.category as Option<ExpenseCategory>,
-//         create_expense.is_essential,
-//         create_expense.date,
-//         Uuid::new_v4(),
-//         user_id
-//     )
-//     .fetch_one(db_pool)
-//     .await
-//     {
-//         Ok(expense) => Ok((StatusCode::CREATED, Json(expense))),
-//         Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
-//     }
-// }
+pub async fn insert_expense(
+    auth_session: AuthSession,
+    db_pool: &Pool<Postgres>,
+    create_expense: UpdateExpense,
+) -> Result<impl IntoResponse, impl IntoResponse> {
+    let user_id = if let Some(user) = auth_session.user {
+        tracing::info!("User logged in");
+        user.id
+    } else {
+        tracing::error!("User not logged in");
+        return Err((StatusCode::UNAUTHORIZED, String::new()));
+    };
+
+    match sqlx::query_as!(
+        Expense,
+        r#"
+        INSERT INTO expenses (description, price, category, is_essential, date, uuid, user_id)
+        VALUES ($1, $2, $3 :: expense_category, $4, $5, $6, $7)
+        RETURNING id, description, price, category as "category: ExpenseCategory", is_essential, date, uuid
+        "#,
+        create_expense.description,
+        create_expense.price,
+        create_expense.category as Option<ExpenseCategory>,
+        create_expense.is_essential,
+        create_expense.date,
+        Uuid::new_v4(),
+        user_id
+    )
+    .fetch_one(db_pool)
+    .await {
+        Ok(expense) => Ok((StatusCode::CREATED, Json(expense))),
+        Err(e) => {
+            tracing::error!("Error inserting expense: {}", e);
+            Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+        },
+    }
+}

--- a/src/data/service/expenses.rs
+++ b/src/data/service/expenses.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 
 use crate::{
     auth::AuthSession,
-    schema::{Expense, ExpenseCategory, GetExpense, UpdateExpense},
+    schema::{Expense, ExpenseCategory, GetExpense, UpdateExpense, UpdateExpenseApi},
     util::{get_first_day_from_month_or_none, get_last_day_from_month_or_none},
 };
 
@@ -119,14 +119,14 @@ pub async fn get_expense(
     .await
     .unwrap();
 
-    Ok((StatusCode::CREATED, Json(expense)))
+    Ok((StatusCode::FOUND, Json(expense)))
 }
 
 pub async fn update_expense(
     auth_session: AuthSession,
     db_pool: &Pool<Postgres>,
     uuid: Uuid,
-    update_expense: UpdateExpense,
+    update_expense: UpdateExpenseApi,
 ) -> Result<impl IntoResponse, impl IntoResponse> {
     let user_id = if let Some(user) = auth_session.user {
         tracing::info!("User logged in");
@@ -158,7 +158,7 @@ pub async fn update_expense(
     )
     .fetch_one(db_pool)
     .await {
-        Ok(expense) => Ok((StatusCode::CREATED, Json(expense))),
+        Ok(expense) => Ok((StatusCode::OK, Json(expense))),
         Err(e) => {
             tracing::error!("Error updating expense: {}", e);
             Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 #![warn(
     clippy::all,
-//    clippy::restriction,
+    // clippy::restriction,
     clippy::pedantic,
     clippy::nursery,
-//    clippy::cargo,
+    // clippy::cargo,
     nonstandard_style,
     future_incompatible,
     missing_debug_implementations

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -12,7 +12,6 @@ use uuid::Uuid;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Clone, EnumIter, Deserialize, sqlx::Type, Default)]
 #[sqlx(type_name = "expense_category", rename_all = "lowercase")]
-#[allow(clippy::missing_docs_in_private_items)]
 /// `ExpenseCategory` is an enum with the types of expenses.
 pub enum ExpenseCategory {
     Food,
@@ -54,7 +53,6 @@ impl Display for ExpenseCategory {
 }
 
 #[derive(FromRow, Serialize, Debug, Default)]
-#[allow(clippy::missing_docs_in_private_items)]
 /// Expense is a struct with the fields of an expense.
 pub struct Expense {
     pub id: i32,
@@ -67,7 +65,6 @@ pub struct Expense {
 }
 
 #[derive(Deserialize, Debug)]
-#[allow(clippy::missing_docs_in_private_items)]
 /// `GetExpense` is a struct with the fields of an expense that can be retrieved.
 /// Currently, only the month is supported and it is optional.
 /// If no month is passed, all expenses are retrieved.
@@ -76,8 +73,18 @@ pub struct GetExpense {
     pub month: Option<Months>,
 }
 
+#[derive(Deserialize, Debug)]
+/// `UpdateExpense` is a struct with the fields of an expense that can be updated.
+/// All fields are optional.
+pub struct UpdateExpenseApi {
+    pub description: Option<String>,
+    pub price: Option<f32>,
+    pub category: Option<ExpenseCategory>,
+    pub is_essential: Option<bool>,
+    pub date: Option<NaiveDate>,
+}
+
 #[derive(Deserialize, Debug, Default)]
-#[allow(clippy::missing_docs_in_private_items)]
 /// `UpdateExpense` is a struct with the fields of an expense that can be updated.
 /// All fields are optional.
 pub struct UpdateExpense {


### PR DESCRIPTION
# Description
Added data api services for inserting a new expense, as well as getting, updating and deleting an expense by its uuid.
To optimize this, an index and constraint for unique uuid in expenses table was added.

Also added a documentation for data api usage in api.http.

closes #10

# Todo
This data router should be protected by 2FA, but I still have to think about the architecture for this, like generating the 2FA token from the totp.