### PR TITLE
feat: adding mfa data apis

### DIFF
--- a/src/data/router/auth.rs
+++ b/src/data/router/auth.rs
@@ -1,12 +1,19 @@
 use std::sync::Arc;
 
 use askama_axum::IntoResponse;
-use axum::{extract::State, routing::post, Json, Router};
+use axum::{extract::State, routing::get, Json, Router};
 
 use crate::{auth::AuthSession, hypermedia::schema::auth::MfaTokenForm, AppState};
 
 pub fn private_router() -> Router<Arc<AppState>> {
-    Router::new().route("/api/auth/mfa", post(mfa_verify))
+    Router::new().route("/api/auth/mfa", get(mfa_info).post(mfa_verify))
+}
+
+async fn mfa_info(
+    auth_session: AuthSession,
+    State(shared_state): State<Arc<AppState>>,
+) -> impl IntoResponse {
+    crate::data::service::auth::mfa_info(auth_session, &shared_state.pool).await
 }
 
 async fn mfa_verify(

--- a/src/data/service/auth.rs
+++ b/src/data/service/auth.rs
@@ -1,0 +1,34 @@
+use axum::{http::StatusCode, Json};
+use serde::{Deserialize, Serialize};
+use sqlx::{Pool, Postgres};
+
+use crate::{auth::AuthSession, features::totp::set_otp_secret};
+
+#[derive(Serialize, Deserialize)]
+pub struct MfaInfo {
+    pub otp_url: String,
+}
+
+pub async fn mfa_info(
+    auth_session: AuthSession,
+    db_pool: &Pool<Postgres>,
+) -> Result<Json<MfaInfo>, StatusCode> {
+    let Some(user) = auth_session.user else {
+        return Err(StatusCode::UNAUTHORIZED);
+    };
+    tracing::info!("User logged in");
+
+    // TODO: create logic for changing MFA method
+    if user.otp_enabled {
+        todo!("Create logic for changing MFA method");
+    }
+
+    let totp = set_otp_secret(db_pool, user.id).await.map_err(|e| {
+        tracing::error!(?user.id, "Error setting OTP secret: {e}");
+        return StatusCode::INTERNAL_SERVER_ERROR;
+    })?;
+
+    Ok(Json(MfaInfo {
+        otp_url: totp.otp_url,
+    }))
+}

--- a/src/data/service/mod.rs
+++ b/src/data/service/mod.rs
@@ -1,1 +1,2 @@
+pub mod auth;
 pub mod expenses;

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -1,0 +1,1 @@
+pub mod totp;

--- a/src/features/totp.rs
+++ b/src/features/totp.rs
@@ -1,0 +1,48 @@
+use crate::util::generate_otp_token;
+use anyhow::bail;
+use sqlx::{Pool, Postgres};
+use totp_rs::{Algorithm, Secret, TOTP};
+
+pub struct OtpData {
+    /// `qr_code` is a base64 encoded image that can be rendered embedded in an <img> tag
+    pub qr_code: String,
+    /// `otp_url` is a otpauth:// url that can be rendered as a QR code
+    pub otp_url: String,
+}
+
+pub async fn set_otp_secret(db_pool: &Pool<Postgres>, user_id: i32) -> anyhow::Result<OtpData> {
+    let secret = Secret::Raw(generate_otp_token().as_bytes().to_vec());
+    let mut transaction = db_pool.begin().await?;
+
+    let user_email = sqlx::query!(
+        r#"
+        UPDATE users SET otp_secret = $1 WHERE id = $2
+        RETURNING email
+        "#,
+        secret.to_encoded().to_string(),
+        user_id
+    )
+    .fetch_one(&mut *transaction)
+    .await?;
+
+    let totp = TOTP::new(
+        Algorithm::SHA1,
+        6,
+        1,
+        30,
+        secret.to_bytes().unwrap(),
+        Some("Finnish".to_owned()),
+        user_email.email,
+    )?;
+
+    transaction.commit().await?;
+
+    let Ok(qr_code) = totp.get_qr_base64() else {
+        bail!("Failed to generate QR code from totp");
+    };
+
+    Ok(OtpData {
+        qr_code,
+        otp_url: totp.get_url(),
+    })
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod client;
 mod constant;
 mod data;
 mod data_structs;
+mod features;
 mod hypermedia;
 /// Module containing the database schemas and i/o schemas for hypermedia and data apis.
 mod schema;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -102,6 +102,10 @@ pub struct UpdateExpense {
 
 /// Function to set the default value for `is_essential` in `UpdateExpense` to be Some(false).
 #[allow(clippy::unnecessary_wraps)]
+//#[allow(
+//    clippy::unnecessary_wraps,
+//    reason = "Needs to return option for custom deserializer"
+//)]
 const fn default_is_essential_to_false() -> Option<bool> {
     return Some(false);
 }


### PR DESCRIPTION
# Description
Adding mfa_info api for use in the mobile, where we return the url for authenticator apps
The implementation is currently bad, but we're in a rush.

Maybe later we need to change the behaviour of resetting the mfa_secrets on every request haha.

Also, added a hint of a large restructure I'll do later into layers:
- routes
- services
- features
- db / clients