### PR TITLE
fix: pluggy widget rendering api

### DIFF
--- a/src/client/svix.rs
+++ b/src/client/svix.rs
@@ -10,6 +10,7 @@ pub async fn create_user_app(svix_api_key: &str, user_id: i32) -> anyhow::Result
         .create(
             ApplicationIn {
                 name: format!("finnish-{user_id}"),
+                uid: Some(user_id.to_string()),
                 ..ApplicationIn::default()
             },
             None,
@@ -19,10 +20,7 @@ pub async fn create_user_app(svix_api_key: &str, user_id: i32) -> anyhow::Result
     Ok(app)
 }
 
-pub async fn create_user_endpoint(
-    svix_api_key: &str,
-    svix_user_app_id: String,
-) -> anyhow::Result<String> {
+pub async fn create_user_endpoint(svix_api_key: &str, user_id: i32) -> anyhow::Result<String> {
     let svix = Svix::new(svix_api_key.to_owned(), None);
 
     let base = Url::parse(ENDPOINT_URL_PREFIX)?;
@@ -32,7 +30,7 @@ pub async fn create_user_endpoint(
     let endpoint = svix
         .endpoint()
         .create(
-            svix_user_app_id,
+            user_id.to_string(),
             EndpointIn {
                 url: joined.to_string(),
                 description: Some("Pluggy connect endpoint".to_string()),

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -350,29 +350,6 @@ macro_rules! WEAK_NEW_PASSWORD {
     };
 }
 
-macro_rules! DELETE_EXPENSE_MODAL {
-    () => {
-        "<dialog id=\"delete-expense-modal\" open>
-            <article>
-                <a href=\"#close\"
-                  aria-label=\"Close\"
-                  class=\"close\"
-                  _=\"on click trigger toggleModal\">
-                </a>
-                <h3>Delete the expense</h3>
-                <p>Are you sure you want to delete this expense?</p>
-                <footer>
-                    <div class=\"grid\">
-                        <button hx-delete=\"/expenses/{}\" hx-target=\"#delete-modal-here\" class=\"contrast\" hx-trigger=\"click\">Delete</button>
-                        <button _=\"on click trigger toggleModal\" type=\"button\">Close</button>
-                    </div>
-                </footer>
-            </article>
-        </dialog>"
-    };
-}
-
-pub(crate) use DELETE_EXPENSE_MODAL;
 pub(crate) use INVALID_EMAIL;
 pub(crate) use INVALID_USERNAME;
 pub(crate) use MATCHING_NEW_PASSWORDS;

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -353,3 +353,7 @@ pub struct DeleteExpenseModal {
 pub struct PluggyConnectWidgetTemplate {
     pub access_token: String,
 }
+
+#[derive(Template, Default)]
+#[template(path = "pluggy_widget_modal_error.html")]
+pub struct PluggyWidgetModalErrorTemplate {}

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -343,6 +343,12 @@ pub struct ExpenseRowTemplate {
 }
 
 #[derive(Template, Default)]
+#[template(path = "delete_expense_modal.html")]
+pub struct DeleteExpenseModal {
+    pub expense_uuid: Uuid,
+}
+
+#[derive(Template, Default)]
 #[template(path = "pluggy_connect_widget.html")]
 pub struct PluggyConnectWidgetTemplate {
     pub access_token: String,

--- a/templates/delete_expense_modal.html
+++ b/templates/delete_expense_modal.html
@@ -1,0 +1,17 @@
+<dialog id="delete-expense-modal" open>
+    <article>
+        <a href="#close"
+          aria-label="Close"
+          class="close"
+          _="on click trigger toggleModal">
+        </a>
+        <h3>Delete the expense</h3>
+        <p>Are you sure you want to delete this expense?</p>
+        <footer>
+            <div class="grid">
+                <button hx-delete="/expenses/{{ expense_uuid }}" hx-target="#delete-modal-here" class="contrast" hx-trigger="click">Delete</button>
+                <button _="on click trigger toggleModal" type="button">Close</button>
+            </div>
+        </footer>
+    </article>
+</dialog>

--- a/templates/expenses.html
+++ b/templates/expenses.html
@@ -8,12 +8,25 @@
 <script nonce="{{ nonce }}" src="/js/hyperscript.min.js"></script>
 <script nonce="{{ nonce }}" src="/js/plotly-strict-2.28.0.min.js" charset="utf-8"></script>
 <script nonce="{{ nonce }}" src="/js/pluggy-connect.js"></script>
+<script nonce="{{ nonce }}" src="/js/response-targets.js"></script>
 {% endblock %}
 
 {% block content %}
 
 <section class="section" id="expenses">
 <h3>{{ username }}'s Expenses</h3>
+
+<section class="section" id="openfinance">
+<div hx-ext="response-targets">
+    <div id="response-div"></div>
+    <button hx-get="/expenses/pluggy-widget"
+            hx-target-error="#pluggy-modal-here" 
+    >
+        Sync with Pluggy
+    </button>
+    <div id="pluggy-modal-here" _="on toggleModal toggle @open on #pluggy-widget-error-modal"></div>
+</div>
+</section>
 
 <form hx-get="/expenses" hx-target="#expenses-table-body" hx-trigger="load, refresh-table from:body, change from:#month">
     <div class="grid">
@@ -29,15 +42,9 @@
         </select>
 
         <button _="on click toggle @open on #modal-example" class="contrast" type="button">Add Expense</button>
-        <button hx-get="/expenses/pluggy-widget"
-                hx-trigger="click"
-                class="btn btn-contrast"
-                type="button"
-        >
-            Sync with Pluggy
-        </button>
     </div>
 </form>
+
 <div hx-get="/expenses/plots"
      hx-target="#expenses-plots"
      hx-trigger="load, change from:#month, refresh-table from:body, refresh-plots from:body"

--- a/templates/pluggy_widget_modal_error.html
+++ b/templates/pluggy_widget_modal_error.html
@@ -1,0 +1,16 @@
+<dialog id="pluggy-widget-error-modal" open>
+  <article>
+    <a href="#close"
+      aria-label="Close"
+      class="close"
+      _="on click trigger toggleModal">
+    </a>
+    <h2>Some error happened :(</h2>
+    <p>
+        We are very sorry, but some error happened when connecting to the OpenFinance API.
+    </p>
+    <footer>
+      <button _="on click trigger toggleModal" type="button">Close</button>
+    </footer>
+  </article>
+</dialog>


### PR DESCRIPTION
# Description
The widget was returning an error, due to webhook endpoint not being created.
This happened because I had just set the svix app id to be a dummy value, which wasn't present in my account, and so it errored.

This PR changes the webhook implementation to be stateless, using the uids (user_ids).

Also, we now return a modal with an error message instead of unwrapping and blowing. 